### PR TITLE
Implement "reverse inheritance" feature

### DIFF
--- a/docs/features.adoc
+++ b/docs/features.adoc
@@ -11,6 +11,7 @@ Basic features offered by the product are following
 * Inheritance
 ** File-level Inheritance
 ** Node-level Inheritance
+** Reverse Inheritance
 ** Script-output Inheritance
 ** Yaml inheritance
 * Templating ("eval" feature)
@@ -21,29 +22,30 @@ And usage of them will be discussed in this section.
 In this section, we introduce features of the product using following data.
 
 * link:examples/A.json[A.json]
-[source, json]
+[source,json]
 include::examples/A.json[]
 
 * link:examples/AA.json[AA.json]
-[source, json]
+[source,json]
 include::examples/AA.json[]
 
 * link:examples/B.json[B.json]
-[source, json]
+[source,json]
 include::examples/B.json[]
 
 * link:examples/T.json[T.json]
-[source, json]
+[source,json]
 include::examples/T.json[]
 
 === Inheritance
+
 ==== File-level Inheritance
 
 In programming languages, inheritance is an indispensable technique to reuse a component.
 `jq-front` offers it for the purpose.
 A usage example is as follows.
 
-[source, json]
+[source,json]
 .I.json
 ----
 {
@@ -58,8 +60,7 @@ jq-front I.json
 
 `I.json` will be rendered into the following JSON object with this command line.
 
-
-[source, json]
+[source,json]
 .File-level Inheritance output
 ----
 {
@@ -74,7 +75,7 @@ Multiple inheritance is also supported by `jq-front`.
 Just by listing file names of JSONs to be inherited, multiple inheritance happens, like `"$extends": ["A.json", "B.json"]`.
 When both `A.json` and `B.json` have attributes at the same path, `A.json` side's value will be used.
 
-[source, json]
+[source,json]
 .J.json
 ----
 {
@@ -84,7 +85,7 @@ When both `A.json` and `B.json` have attributes at the same path, `A.json` side'
 
 That is, `J.json` will be rendered into following output.
 
-[source, json]
+[source,json]
 .File-level Multiple Inheritance output
 ----
 {
@@ -100,7 +101,7 @@ For instance, one is for authentication information and the other is for GUI fla
 
 JSON objects that are inherited can also inherit some other JSON files.
 
-[source, json]
+[source,json]
 .K.json
 ----
 {
@@ -110,7 +111,7 @@ JSON objects that are inherited can also inherit some other JSON files.
 
 That is, `K.json` is rendered into a following JSON file.
 
-[source, json]
+[source,json]
 .File-level Inheritance output (2)
 ----
 {
@@ -129,7 +130,7 @@ It will be checked and result in an error.
 "Node-level Inheritance" refers to an inheritance happens on an internal (object) node of a given JSON file.
 Although it is implemented as a separate mechanism from the file-level one as it will be discussed in "Design" section, it behaves almost the same as the "file-level" one.
 
-[source, json]
+[source,json]
 .L.json
 ----
 {
@@ -140,7 +141,7 @@ Although it is implemented as a separate mechanism from the file-level one as it
 }
 ----
 
-[source, json]
+[source,json]
 .Node-level Inheritance output
 ----
 {
@@ -155,7 +156,7 @@ As it worked for File-level Inheritance, multiple inheritance works also for Nod
 
 However, for internal nodes, you can also reference "local" nodes not only external files.
 
-[source, json]
+[source,json]
 .P.json
 ----
 {
@@ -177,7 +178,7 @@ These nodes can be referenced through "node-level inheritance feature" as shown 
 Note that you do not need to specify `.json` extension.
 And `P.json` will result in following output.
 
-[source, json]
+[source,json]
 .Local Node Inheritance output
 ----
 {
@@ -188,13 +189,59 @@ And `P.json` will result in following output.
 }
 ----
 
+==== Reverse Inheritance
+
+When you design a data structure using JSON (or YAML), you often find that you want to define a template, where user custom files are inserted.
+
+[source,json]
+----
+{
+  "company": "SPQR",
+  "laptopSpec": {
+    "cpu": "M1",
+    "mem": "16GB",
+    "storage": "512GB"
+  },
+  "userConfig" : {
+    "userName": "eval:$(whoami)",
+    "preferredShell": "zsh",
+    "preferredWindowManager": "twm"
+  }
+}
+----
+
+Suppose that your users have their user preference files at `/userhome/.yourapp/config` as a JSON file.
+You are thinking of overriding the elements under `userConfig` by the JSON config file.
+But using the normal inheritance (`$extends`) here will not help.
+Because the values you define in the base file as default values will override the user specific configuration.
+Not the other way around.
+What you can do here is "reverse inheritance" with the `$includes` keyword.
+
+[source,json]
+----
+{
+  "company": "SPQR",
+  "laptopSpec": {
+    "cpu": "M1",
+    "mem": "16GB",
+    "storage": "512GB"
+  },
+  "userConfig" : {
+    "$includes": [ "/userhome/.yourapp/config" ],
+    "userName": "eval:$(whoami)",
+    "preferredShell": "zsh",
+    "preferredWindowManager": "twm"
+  }
+}
+----
+
 ==== Script Inheritance
 
 `jq-front` can use the output from your shell as a file to be extended if it is a JSON node.
 
 For instance, if you have a following script file: `S.sh`, which prints something like `{"S":"shell"}`.
 
-[source, bash]
+[source,bash]
 .S.sh
 ----
 echo '{"S":"shell-'${1}'"}'
@@ -229,13 +276,12 @@ This results in a file as follows.
 The component `bash -eu` is a program with which the script (`S.sh`) is executed.
 This feature is still experimental.
 
-
 ==== Yaml file inheritance
 
 `jq-front` can handle YAML files also.
 If you have following two files,
 
-[source, yaml]
+[source,yaml]
 .A.yml
 ----
 ---
@@ -244,7 +290,7 @@ o: A
 y: Y
 ----
 
-[source, json]
+[source,json]
 ----
 {
   "$extends": [ "A.yml" ],
@@ -254,7 +300,7 @@ y: Y
 
 The output will be like following
 
-[source, json]
+[source,json]
 ----
 {
   "a": "A",
@@ -263,7 +309,6 @@ The output will be like following
 }
 ----
 
-
 This feature is still experimental.
 
 === Templating
@@ -271,7 +316,7 @@ This feature is still experimental.
 Sometimes we need to compose a value of text node from a value of another.
 Following is such an example.
 
-[source, json]
+[source,json]
 .Version file
 ----
 {
@@ -287,7 +332,7 @@ Templating is a feature to offer a solution to this challenge.
 
 We can describe this relationship by using the templating feature of `jq-front`.
 
-[source, json]
+[source,json]
 .T.json
 ----
 {
@@ -302,7 +347,8 @@ Once you render this file with `jq-front`, you will get the first file (Version 
 Not only built-in functions but also any commands (bash expressions) valid on a platform on which `jq-front` is running can be used here.
 
 For instance, following is a valid input to `jq-front`.
-[source, json]
+[source,json]
+
 ----
 {
   "releaseVersion": "2.12.0",
@@ -311,7 +357,8 @@ For instance, following is a valid input to `jq-front`.
 ----
 
 And this will result in an output below.
-[source, json]
+[source,json]
+
 ----
 {
   "releaseVersion": "2.12.0",

--- a/docs/features.html
+++ b/docs/features.html
@@ -479,6 +479,9 @@ To specify JSON objects to be inherited, <code>jq-front</code> searches for keys
 <p>Node-level Inheritance</p>
 </li>
 <li>
+<p>Reverse Inheritance</p>
+</li>
+<li>
 <p>Script-output Inheritance</p>
 </li>
 <li>
@@ -727,6 +730,55 @@ And <code>P.json</code> will result in following output.</p>
 </div>
 </div>
 <div class="sect3">
+<h4 id="_reverse_inheritance">Reverse Inheritance</h4>
+<div class="paragraph">
+<p>When you design a data structure using JSON (or YAML), you often find that you want to define a template, where user custom files are inserted.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-json" data-lang="json">{
+  "company": "SPQR",
+  "laptopSpec": {
+    "cpu": "M1",
+    "mem": "16GB",
+    "storage": "512GB"
+  },
+  "userConfig" : {
+    "userName": "eval:$(whoami)",
+    "preferredShell": "zsh",
+    "preferredWindowManager": "twm"
+  }
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Suppose that your users have their user preference files at <code>/userhome/.yourapp/config</code> as a JSON file.
+You are thinking of overriding the elements under <code>userConfig</code> by the JSON config file.
+But using the normal inheritance (<code>$extends</code>) here will not help.
+Because the values you define in the base file as default values will override the user specific configuration.
+Not the other way around.
+What you can do here is "reverse inheritance" with the <code>$includes</code> keyword.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-json" data-lang="json">{
+  "company": "SPQR",
+  "laptopSpec": {
+    "cpu": "M1",
+    "mem": "16GB",
+    "storage": "512GB"
+  },
+  "userConfig" : {
+    "$includes": [ "/userhome/.yourapp/config" ],
+    "userName": "eval:$(whoami)",
+    "preferredShell": "zsh",
+    "preferredWindowManager": "twm"
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
 <h4 id="_script_inheritance">Script Inheritance</h4>
 <div class="paragraph">
 <p><code>jq-front</code> can use the output from your shell as a file to be extended if it is a JSON node.</p>
@@ -889,7 +941,7 @@ And to enable it explicitly, you can use <code>-e</code> (<code>--enable-templat
 </div>
 <div id="footer">
 <div id="footer-text">
-Last updated 2022-05-18 08:46:23 UTC
+Last updated 2022-10-15 07:49:16 UTC
 </div>
 </div>
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -435,6 +435,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 #footer{background:none}
 #footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
 @media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+
 // For tabs
 body {font-family: Arial;}
 
@@ -500,7 +501,7 @@ body {font-family: Arial;}
 </div>
 <div class="imageblock">
 <div class="content">
-<img src="images/pipeline.png" alt="pipeline" width="920" height="574">
+<img src="images/pipeline.png" alt="pipeline" width="920" height="574"/>
 </div>
 <div class="title">Figure 1. jq-front’s pipeline</div>
 </div>
@@ -580,7 +581,8 @@ Note that it is not defined in <code>jq</code> 's manual<a href="#jq">[jq]</a> h
 </div>
 </div>
 </div>
-</div><div class="paragraph text-right"><p>
+</div>
+<div class="paragraph text-right"><p>
 <a href="design.html">open this page in a window</a>
 </p></div>
 </div>
@@ -628,7 +630,8 @@ However, due to the specification of <code>bash</code>, if you use command subst
 </div>
 </div>
 </div>
-</div><div class="paragraph text-right"><p>
+</div>
+<div class="paragraph text-right"><p>
 <a href="faq.html">open this page in a window</a>
 </p></div>
 </div>
@@ -659,6 +662,9 @@ To specify JSON objects to be inherited, <code>jq-front</code> searches for keys
 </li>
 <li>
 <p>Node-level Inheritance</p>
+</li>
+<li>
+<p>Reverse Inheritance</p>
 </li>
 <li>
 <p>Script-output Inheritance</p>
@@ -909,6 +915,55 @@ And <code>P.json</code> will result in following output.</p>
 </div>
 </div>
 <div class="sect3">
+<h4 id="_reverse_inheritance">Reverse Inheritance</h4>
+<div class="paragraph">
+<p>When you design a data structure using JSON (or YAML), you often find that you want to define a template, where user custom files are inserted.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-json" data-lang="json">{
+  "company": "SPQR",
+  "laptopSpec": {
+    "cpu": "M1",
+    "mem": "16GB",
+    "storage": "512GB"
+  },
+  "userConfig" : {
+    "userName": "eval:$(whoami)",
+    "preferredShell": "zsh",
+    "preferredWindowManager": "twm"
+  }
+}</code></pre>
+</div>
+</div>
+<div class="paragraph">
+<p>Suppose that your users have their user preference files at <code>/userhome/.yourapp/config</code> as a JSON file.
+You are thinking of overriding the elements under <code>userConfig</code> by the JSON config file.
+But using the normal inheritance (<code>$extends</code>) here will not help.
+Because the values you define in the base file as default values will override the user specific configuration.
+Not the other way around.
+What you can do here is "reverse inheritance" with the <code>$includes</code> keyword.</p>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight"><code class="language-json" data-lang="json">{
+  "company": "SPQR",
+  "laptopSpec": {
+    "cpu": "M1",
+    "mem": "16GB",
+    "storage": "512GB"
+  },
+  "userConfig" : {
+    "$includes": [ "/userhome/.yourapp/config" ],
+    "userName": "eval:$(whoami)",
+    "preferredShell": "zsh",
+    "preferredWindowManager": "twm"
+  }
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
 <h4 id="_script_inheritance">Script Inheritance</h4>
 <div class="paragraph">
 <p><code>jq-front</code> can use the output from your shell as a file to be extended if it is a JSON node.</p>
@@ -1068,7 +1123,8 @@ And to enable it explicitly, you can use <code>-e</code> (<code>--enable-templat
 </div>
 </div>
 </div>
-</div><div class="paragraph text-right"><p>
+</div>
+<div class="paragraph text-right"><p>
 <a href="features.html">open this page in a window</a>
 </p></div>
 </div>
@@ -1191,7 +1247,8 @@ To install docker, visit</p>
 </div>
 </div>
 </div>
-</div><div class="paragraph text-right"><p>
+</div>
+<div class="paragraph text-right"><p>
 <a href="installation.html">open this page in a window</a>
 </p></div>
 </div>
@@ -1335,7 +1392,8 @@ It takes seconds to process even a relatively simple and small file.</p>
 </div>
 </div>
 </div>
-</div><div class="paragraph text-right"><p>
+</div>
+<div class="paragraph text-right"><p>
 <a href="limitationsAndFutureWork.html">open this page in a window</a>
 </p></div>
 </div>
@@ -1439,7 +1497,8 @@ Entries in the variable are separated by colons(<code>:</code>).</p>
 </div>
 </div>
 </div>
-</div><div class="paragraph text-right"><p>
+</div>
+<div class="paragraph text-right"><p>
 <a href="manual.html">open this page in a window</a>
 </p></div>
 </div>
@@ -1769,8 +1828,8 @@ In case cyclic reference is found during this process, it will be reported and t
 <h4 id="_examples">Examples</h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
 </colgroup>
 <thead>
 <tr>
@@ -1908,8 +1967,8 @@ This function is intended for internal use.</p>
 <h4 id="_examples_2">Examples</h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
 </colgroup>
 <thead>
 <tr>
@@ -2011,8 +2070,8 @@ An "entry" means a string element in an array or a pair of key and value in an o
 <h4 id="_examples_3">Examples</h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
 </colgroup>
 <thead>
 <tr>
@@ -2146,8 +2205,8 @@ Thus, <code>cur</code> function calls in inherited files are evaluated based on 
 <h4 id="_examples_4">Examples</h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
 </colgroup>
 <thead>
 <tr>
@@ -2263,8 +2322,8 @@ In this case, the evaluation will not stop at the point and <code>jq-front</code
 <h4 id="_examples_5">Examples</h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
 </colgroup>
 <thead>
 <tr>
@@ -2342,7 +2401,8 @@ And as you see, you are now able to call the function you defined, <code>hello_w
 </div>
 </div>
 </div>
-</div><div class="paragraph text-right"><p>
+</div>
+<div class="paragraph text-right"><p>
 <a href="syntax.html">open this page in a window</a>
 </p></div>
 </div>
@@ -2369,8 +2429,8 @@ For instance, under a situation, where we need to generate similar but slightly 
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
 </colgroup>
 <thead>
 <tr>
@@ -2439,8 +2499,8 @@ For instance, under a situation, where we need to generate similar but slightly 
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
 </colgroup>
 <thead>
 <tr>
@@ -2492,8 +2552,8 @@ Although I am a bit skeptical at the discussion from some view points (e.g., use
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 50%;"/>
+<col style="width: 50%;"/>
 </colgroup>
 <thead>
 <tr>
@@ -2597,32 +2657,32 @@ This approach delivers you another benefit, where you can select another solutio
 <div class="ulist bibliography">
 <ul class="bibliography">
 <li>
-<p><a id="jq-front"></a>[1] jq-front project in github.org. <a href="https://github.com/dakusui/jq-front">jq-front</a>:
+<p><a id="jq-front"/>[1] jq-front project in github.org. <a href="https://github.com/dakusui/jq-front">jq-front</a>:
 2019</p>
 </li>
 <li>
-<p><a id="Cfront"></a>[2] Cfront article in en.wikipedia.org. <a href="https://en.wikipedia.org/wiki/Cfront">Cfront</a>:
+<p><a id="Cfront"/>[2] Cfront article in en.wikipedia.org. <a href="https://en.wikipedia.org/wiki/Cfront">Cfront</a>:
 2019</p>
 </li>
 <li>
-<p><a id="cr"></a>[3] Thayne McCombs. <a href="https://www.lucidchart.com/techblog/2018/07/16/why-json-isnt-a-good-configuration-language/">Why JSON isn’t a Good Configuration Language</a>:
+<p><a id="cr"/>[3] Thayne McCombs. <a href="https://www.lucidchart.com/techblog/2018/07/16/why-json-isnt-a-good-configuration-language/">Why JSON isn’t a Good Configuration Language</a>:
 2018.</p>
 </li>
 <li>
-<p><a id="yaml"></a>[4] YAML article in en.wikipedia.org. <a href="https://en.wikipedia.org/wiki/YAML">YAML</a>:
+<p><a id="yaml"/>[4] YAML article in en.wikipedia.org. <a href="https://en.wikipedia.org/wiki/YAML">YAML</a>:
 2019</p>
 </li>
 <li>
-<p><a id="json"></a>[5] json.org. <a href="http://www.json.org/">JSON</a>:2019</p>
+<p><a id="json"/>[5] json.org. <a href="http://www.json.org/">JSON</a>:2019</p>
 </li>
 <li>
-<p><a id="jq"></a>[6]  jq <a href="https://stedolan.github.io/jq/manual/">jq manual</a>:2019</p>
+<p><a id="jq"/>[6]  jq <a href="https://stedolan.github.io/jq/manual/">jq manual</a>:2019</p>
 </li>
 <li>
-<p><a id="stackoverflow"></a>[7] More complex inheritance in YAML? <a href="https://stackoverflow.com/questions/14184971/more-complex-inheritance-in-yaml">stackoverflow</a>:2019</p>
+<p><a id="stackoverflow"/>[7] More complex inheritance in YAML? <a href="https://stackoverflow.com/questions/14184971/more-complex-inheritance-in-yaml">stackoverflow</a>:2019</p>
 </li>
 <li>
-<p><a id="hocon"></a> HOCON (Human-Optimized Config Object Notation) <a href="https://github.com/lightbend/config">HOCON</a>:2020</p>
+<p><a id="hocon"/> HOCON (Human-Optimized Config Object Notation) <a href="https://github.com/lightbend/config">HOCON</a>:2020</p>
 </li>
 </ul>
 </div>
@@ -2631,7 +2691,8 @@ This approach delivers you another benefit, where you can select another solutio
 </div>
 </div>
 </div>
-</div><div class="paragraph text-right"><p>
+</div>
+<div class="paragraph text-right"><p>
 <a href="top.html">open this page in a window</a>
 </p></div>
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -435,7 +435,6 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 #footer{background:none}
 #footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
 @media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
-
 // For tabs
 body {font-family: Arial;}
 
@@ -501,7 +500,7 @@ body {font-family: Arial;}
 </div>
 <div class="imageblock">
 <div class="content">
-<img src="images/pipeline.png" alt="pipeline" width="920" height="574"/>
+<img src="images/pipeline.png" alt="pipeline" width="920" height="574">
 </div>
 <div class="title">Figure 1. jq-front’s pipeline</div>
 </div>
@@ -581,8 +580,7 @@ Note that it is not defined in <code>jq</code> 's manual<a href="#jq">[jq]</a> h
 </div>
 </div>
 </div>
-</div>
-<div class="paragraph text-right"><p>
+</div><div class="paragraph text-right"><p>
 <a href="design.html">open this page in a window</a>
 </p></div>
 </div>
@@ -630,8 +628,7 @@ However, due to the specification of <code>bash</code>, if you use command subst
 </div>
 </div>
 </div>
-</div>
-<div class="paragraph text-right"><p>
+</div><div class="paragraph text-right"><p>
 <a href="faq.html">open this page in a window</a>
 </p></div>
 </div>
@@ -1071,8 +1068,7 @@ And to enable it explicitly, you can use <code>-e</code> (<code>--enable-templat
 </div>
 </div>
 </div>
-</div>
-<div class="paragraph text-right"><p>
+</div><div class="paragraph text-right"><p>
 <a href="features.html">open this page in a window</a>
 </p></div>
 </div>
@@ -1195,8 +1191,7 @@ To install docker, visit</p>
 </div>
 </div>
 </div>
-</div>
-<div class="paragraph text-right"><p>
+</div><div class="paragraph text-right"><p>
 <a href="installation.html">open this page in a window</a>
 </p></div>
 </div>
@@ -1340,8 +1335,7 @@ It takes seconds to process even a relatively simple and small file.</p>
 </div>
 </div>
 </div>
-</div>
-<div class="paragraph text-right"><p>
+</div><div class="paragraph text-right"><p>
 <a href="limitationsAndFutureWork.html">open this page in a window</a>
 </p></div>
 </div>
@@ -1445,8 +1439,7 @@ Entries in the variable are separated by colons(<code>:</code>).</p>
 </div>
 </div>
 </div>
-</div>
-<div class="paragraph text-right"><p>
+</div><div class="paragraph text-right"><p>
 <a href="manual.html">open this page in a window</a>
 </p></div>
 </div>
@@ -1776,8 +1769,8 @@ In case cyclic reference is found during this process, it will be reported and t
 <h4 id="_examples">Examples</h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;"/>
-<col style="width: 50%;"/>
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
@@ -1915,8 +1908,8 @@ This function is intended for internal use.</p>
 <h4 id="_examples_2">Examples</h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;"/>
-<col style="width: 50%;"/>
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
@@ -2018,8 +2011,8 @@ An "entry" means a string element in an array or a pair of key and value in an o
 <h4 id="_examples_3">Examples</h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;"/>
-<col style="width: 50%;"/>
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
@@ -2153,8 +2146,8 @@ Thus, <code>cur</code> function calls in inherited files are evaluated based on 
 <h4 id="_examples_4">Examples</h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;"/>
-<col style="width: 50%;"/>
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
@@ -2270,8 +2263,8 @@ In this case, the evaluation will not stop at the point and <code>jq-front</code
 <h4 id="_examples_5">Examples</h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;"/>
-<col style="width: 50%;"/>
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
@@ -2349,8 +2342,7 @@ And as you see, you are now able to call the function you defined, <code>hello_w
 </div>
 </div>
 </div>
-</div>
-<div class="paragraph text-right"><p>
+</div><div class="paragraph text-right"><p>
 <a href="syntax.html">open this page in a window</a>
 </p></div>
 </div>
@@ -2377,8 +2369,8 @@ For instance, under a situation, where we need to generate similar but slightly 
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;"/>
-<col style="width: 50%;"/>
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
@@ -2447,8 +2439,8 @@ For instance, under a situation, where we need to generate similar but slightly 
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;"/>
-<col style="width: 50%;"/>
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
@@ -2500,8 +2492,8 @@ Although I am a bit skeptical at the discussion from some view points (e.g., use
 </div>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
-<col style="width: 50%;"/>
-<col style="width: 50%;"/>
+<col style="width: 50%;">
+<col style="width: 50%;">
 </colgroup>
 <thead>
 <tr>
@@ -2605,32 +2597,32 @@ This approach delivers you another benefit, where you can select another solutio
 <div class="ulist bibliography">
 <ul class="bibliography">
 <li>
-<p><a id="jq-front"/>[1] jq-front project in github.org. <a href="https://github.com/dakusui/jq-front">jq-front</a>:
+<p><a id="jq-front"></a>[1] jq-front project in github.org. <a href="https://github.com/dakusui/jq-front">jq-front</a>:
 2019</p>
 </li>
 <li>
-<p><a id="Cfront"/>[2] Cfront article in en.wikipedia.org. <a href="https://en.wikipedia.org/wiki/Cfront">Cfront</a>:
+<p><a id="Cfront"></a>[2] Cfront article in en.wikipedia.org. <a href="https://en.wikipedia.org/wiki/Cfront">Cfront</a>:
 2019</p>
 </li>
 <li>
-<p><a id="cr"/>[3] Thayne McCombs. <a href="https://www.lucidchart.com/techblog/2018/07/16/why-json-isnt-a-good-configuration-language/">Why JSON isn’t a Good Configuration Language</a>:
+<p><a id="cr"></a>[3] Thayne McCombs. <a href="https://www.lucidchart.com/techblog/2018/07/16/why-json-isnt-a-good-configuration-language/">Why JSON isn’t a Good Configuration Language</a>:
 2018.</p>
 </li>
 <li>
-<p><a id="yaml"/>[4] YAML article in en.wikipedia.org. <a href="https://en.wikipedia.org/wiki/YAML">YAML</a>:
+<p><a id="yaml"></a>[4] YAML article in en.wikipedia.org. <a href="https://en.wikipedia.org/wiki/YAML">YAML</a>:
 2019</p>
 </li>
 <li>
-<p><a id="json"/>[5] json.org. <a href="http://www.json.org/">JSON</a>:2019</p>
+<p><a id="json"></a>[5] json.org. <a href="http://www.json.org/">JSON</a>:2019</p>
 </li>
 <li>
-<p><a id="jq"/>[6]  jq <a href="https://stedolan.github.io/jq/manual/">jq manual</a>:2019</p>
+<p><a id="jq"></a>[6]  jq <a href="https://stedolan.github.io/jq/manual/">jq manual</a>:2019</p>
 </li>
 <li>
-<p><a id="stackoverflow"/>[7] More complex inheritance in YAML? <a href="https://stackoverflow.com/questions/14184971/more-complex-inheritance-in-yaml">stackoverflow</a>:2019</p>
+<p><a id="stackoverflow"></a>[7] More complex inheritance in YAML? <a href="https://stackoverflow.com/questions/14184971/more-complex-inheritance-in-yaml">stackoverflow</a>:2019</p>
 </li>
 <li>
-<p><a id="hocon"/> HOCON (Human-Optimized Config Object Notation) <a href="https://github.com/lightbend/config">HOCON</a>:2020</p>
+<p><a id="hocon"></a> HOCON (Human-Optimized Config Object Notation) <a href="https://github.com/lightbend/config">HOCON</a>:2020</p>
 </li>
 </ul>
 </div>
@@ -2639,8 +2631,7 @@ This approach delivers you another benefit, where you can select another solutio
 </div>
 </div>
 </div>
-</div>
-<div class="paragraph text-right"><p>
+</div><div class="paragraph text-right"><p>
 <a href="top.html">open this page in a window</a>
 </p></div>
 </div>

--- a/lib/inheritance.sh
+++ b/lib/inheritance.sh
@@ -100,7 +100,7 @@ function expand_nodelevel_inheritances() {
   local _content="${1}" _validation_mode="${2}" _path="${3}"
   local _expanded _expanded_clean _clean _content _ret
   perf "begin"
-  _expanded="$(_expand_nodelevel_inheritances "${_content}" "${_validation_mode}" "${_path}")" ||
+  _expanded="$(_expand_nodelevel_inheritances "${_content}" "${_validation_mode}" "${_path}" '$extends')" ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(1)"
   # shellcheck disable=SC2016
   _clean="$(remove_nodes "${_content}" '$extends')"
@@ -113,17 +113,16 @@ function expand_nodelevel_inheritances() {
 }
 
 function _expand_nodelevel_inheritances() {
-  local _content="${1}" _validation_mode="${2}" _path="${3}"
+  local _content="${1}" _validation_mode="${2}" _path="${3}" _keyword="${4}"
   local _cur='{}' i
   local -a _keys
   perf "begin"
   is_debug_enabled && debug "_content='${_content}'"
   # Intentional single quote to find a keyword that starts with '$'
-  # shellcheck disable=SC2016
-  mapfile -t _keys < <(paths_of "${_content}" '$extends')
+  mapfile -t _keys < <(paths_of "${_content}" "${_keyword}")
   is_effectively_empty_array "${_keys[@]}" && _keys=()
   for i in "${_keys[@]}"; do
-    local _jj _p="${i%.\"\$extends\"}"
+    local _jj _p="${i%.\"${_keyword}\"}"
     local -a _extendeds
     mapfile -t _extendeds < <(echo "${_content}" | jq -r -c "${i}[]")
     is_effectively_empty_array "${_extendeds[@]}" && _extendeds=()

--- a/lib/inheritance.sh
+++ b/lib/inheritance.sh
@@ -98,15 +98,15 @@ function expand_inheritances_for_local_nodes() {
 
 function expand_nodelevel_inheritances() {
   local _content="${1}" _validation_mode="${2}" _path="${3}"
-  local _expanded _expanded_clean _clean _content _ret
+  local _expanded _clean _content _ret
   perf "begin"
   _expanded="$(_expand_nodelevel_inheritances "${_content}" "${_validation_mode}" "${_path}" '$extends')" ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(1)"
   # shellcheck disable=SC2016
   _clean="$(remove_nodes "${_content}" '$extends')"
   # shellcheck disable=SC2016
-  _expanded_clean="$(remove_nodes "${_expanded}" '$extends')"
-  _ret=$(merge_object_nodes "${_expanded_clean}" "${_clean}") ||
+  _expanded="$(remove_nodes "${_expanded}" '$extends')"
+  _ret=$(merge_object_nodes "${_expanded}" "${_clean}") ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(2)"
   echo "${_ret}"
   perf "end"

--- a/lib/inheritance.sh
+++ b/lib/inheritance.sh
@@ -107,9 +107,9 @@ function expand_nodelevel_inheritances() {
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(1)"
   _extends_expanded=$(merge_object_nodes "${_extends_expanded}" "${_clean}") ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(2)"
-  _includes_expanded="$(_expand_nodelevel_inheritances "${_content}" "${_validation_mode}" "${_path}" '$extends')" ||
+  _includes_expanded="$(_expand_nodelevel_inheritances "${_content}" "${_validation_mode}" "${_path}" '$includes')" ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(3)"
-  _ret=$(merge_object_nodes "${_includes_expanded}" "${_clean}") ||
+  _ret=$(merge_object_nodes "${_includes_expanded}" "${_extends_expanded}") ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(4)"
   _ret="$(remove_nodes "${_ret}" '$extends')"
   _ret="$(remove_nodes "${_ret}" '$includes')"

--- a/lib/inheritance.sh
+++ b/lib/inheritance.sh
@@ -106,10 +106,11 @@ function expand_nodelevel_inheritances() {
   _extends_expanded="${_content}"
   _extends_expanded="$(_expand_nodelevel_inheritances "${_extends_expanded}" "${_validation_mode}" "${_path}" '$extends')" ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(1)"
-  _extends_expanded="$(remove_nodes "${_extends_expanded}" '$extends')"
   _extends_expanded=$(merge_object_nodes "${_extends_expanded}" "${_clean}") ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(2)"
   _ret="${_extends_expanded}"
+  _ret="$(remove_nodes "${_ret}" '$extends')"
+  _ret="$(remove_nodes "${_ret}" '$includes')"
   echo "${_ret}"
   perf "end"
 }

--- a/lib/inheritance.sh
+++ b/lib/inheritance.sh
@@ -98,17 +98,19 @@ function expand_inheritances_for_local_nodes() {
 
 function expand_nodelevel_inheritances() {
   local _content="${1}" _validation_mode="${2}" _path="${3}"
-  local _extends_expanded _clean _content _ret
+  local _extends_expanded _includes_expanded _clean _content _ret
   perf "begin"
   _clean="${_content}"
   _clean="$(remove_nodes "${_clean}" '$extends')"
   _clean="$(remove_nodes "${_clean}" '$includes')"
-  _extends_expanded="${_content}"
-  _extends_expanded="$(_expand_nodelevel_inheritances "${_extends_expanded}" "${_validation_mode}" "${_path}" '$extends')" ||
+  _extends_expanded="$(_expand_nodelevel_inheritances "${_content}" "${_validation_mode}" "${_path}" '$extends')" ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(1)"
   _extends_expanded=$(merge_object_nodes "${_extends_expanded}" "${_clean}") ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(2)"
-  _ret="${_extends_expanded}"
+  _includes_expanded="$(_expand_nodelevel_inheritances "${_content}" "${_validation_mode}" "${_path}" '$extends')" ||
+    abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(3)"
+  _ret=$(merge_object_nodes "${_includes_expanded}" "${_clean}") ||
+    abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(4)"
   _ret="$(remove_nodes "${_ret}" '$extends')"
   _ret="$(remove_nodes "${_ret}" '$includes')"
   echo "${_ret}"

--- a/lib/inheritance.sh
+++ b/lib/inheritance.sh
@@ -102,8 +102,10 @@ function expand_nodelevel_inheritances() {
   perf "begin"
   _expanded="$(_expand_nodelevel_inheritances "${_content}" "${_validation_mode}" "${_path}")" ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(1)"
-  _clean="$(_remove_meta_nodes "${_content}")"
-  _expanded_clean="$(_remove_meta_nodes "${_expanded}")"
+  # shellcheck disable=SC2016
+  _clean="$(remove_nodes "${_content}" '$extends')"
+  # shellcheck disable=SC2016
+  _expanded_clean="$(remove_nodes "${_expanded}" '$extends')"
   _ret=$(merge_object_nodes "${_expanded_clean}" "${_clean}") ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(2)"
   echo "${_ret}"

--- a/lib/inheritance.sh
+++ b/lib/inheritance.sh
@@ -118,7 +118,7 @@ function _expand_nodelevel_inheritances() {
   is_debug_enabled && debug "_content='${_content}'"
   # Intentional single quote to find a keyword that starts with '$'
   # shellcheck disable=SC2016
-  mapfile -t _keys < <(_paths_of_extends "${_content}")
+  mapfile -t _keys < <(paths_of "${_content}" '$extends')
   is_effectively_empty_array "${_keys[@]}" && _keys=()
   for i in "${_keys[@]}"; do
     local _jj _p="${i%.\"\$extends\"}"
@@ -152,6 +152,7 @@ function _expand_nodelevel_inheritances() {
   perf "end"
   echo "${_cur}" | jq -r -c .
 }
+
 # "
 function materialize_local_nodes() {
   local _content="${1}"

--- a/lib/inheritance.sh
+++ b/lib/inheritance.sh
@@ -109,7 +109,7 @@ function expand_nodelevel_inheritances() {
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(2)"
   _includes_expanded="$(_expand_nodelevel_inheritances "${_content}" "${_validation_mode}" "${_path}" '$includes')" ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(3)"
-  _ret=$(merge_object_nodes "${_includes_expanded}" "${_extends_expanded}") ||
+  _ret=$(merge_object_nodes "${_extends_expanded}" "${_includes_expanded}") ||
     abort "Failed to expand node level inheritance for node:'$(trim "${_content}")'(4)"
   _ret="$(remove_nodes "${_ret}" '$extends')"
   _ret="$(remove_nodes "${_ret}" '$includes')"
@@ -139,7 +139,13 @@ function _expand_nodelevel_inheritances() {
         local _cur_piece _next_piece
         _cur_piece="$(echo "${_cur}" | jq -r -c "${_p}")"
         _next_piece="$(nodepool_read_nodeentry "${_jj}" "${_validation_mode}" "${_path}")"
-        _merged_piece_content="$(merge_object_nodes "${_next_piece}" "${_cur_piece}")"
+        if [[ "${_keyword}" == '$extends' ]]; then
+          _merged_piece_content="$(merge_object_nodes "${_next_piece}" "${_cur_piece}")"
+        elif [[ "${_keyword}" == '$includes' ]]; then
+          _merged_piece_content="$(merge_object_nodes "${_cur_piece}" "${_next_piece}")"
+        else
+          abort "Unknown keyword: '${_keyword}' was specified."
+        fi
         # shellcheck disable=SC2181
         [[ $? == 0 ]] || abort "Failed to merge node:'$(trim "${_cur}")' with _nodeentry:'${_jj}'"
       else

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -3,13 +3,14 @@ _JSON_SH=yes
 
 source "$(dirname "${BASH_SOURCE[0]}")/core.sh"
 
-function _remove_meta_nodes() {
-  local _content="${1}"
+# Remove paths which end with a given keyword from a JSON object and prints it.
+function remove_nodes() {
+  local _content="${1}" _keyword="${2}"
   if is_object "${_content}"; then
     local _keys i
     # Intentional single quote to find a keyword that starts with '$'
     # shellcheck disable=SC2016
-    mapfile -t _keys < <(paths_of "${_content}" '$extends') || _keys=()
+    mapfile -t _keys < <(paths_of "${_content}" "${_keyword}") || _keys=()
     for i in "${_keys[@]}"; do
       local _next
       _next="$(echo "${_content}" | jq ".|del(${i})")"
@@ -19,6 +20,7 @@ function _remove_meta_nodes() {
   echo "${_content}"
 }
 
+# List paths in a json object which end with a given keyword.
 function paths_of() {
   local _content="${1}" _keyword="${2}"
   echo "${_content}" | jq -r -c -L "${JF_BASEDIR}/lib" '#---

--- a/lib/json.sh
+++ b/lib/json.sh
@@ -9,7 +9,7 @@ function _remove_meta_nodes() {
     local _keys i
     # Intentional single quote to find a keyword that starts with '$'
     # shellcheck disable=SC2016
-    mapfile -t _keys < <(_paths_of_extends "${_content}") || _keys=()
+    mapfile -t _keys < <(paths_of "${_content}" '$extends') || _keys=()
     for i in "${_keys[@]}"; do
       local _next
       _next="$(echo "${_content}" | jq ".|del(${i})")"
@@ -19,12 +19,12 @@ function _remove_meta_nodes() {
   echo "${_content}"
 }
 
-function _paths_of_extends() {
-  local _content="${1}"
+function paths_of() {
+  local _content="${1}" _keyword="${2}"
   echo "${_content}" | jq -r -c -L "${JF_BASEDIR}/lib" '#---
 import "shared" as shared;
 
-[paths(..)|. as $p|.[-1]|select(tostring=="$extends")|$p]
+[paths(..)|. as $p|.[-1]|select(tostring=="'"${_keyword}"'")|$p]
               |sort
               |sort_by(length)
               |.[]

--- a/tests/inheritance/reverse/filelevel/A.json
+++ b/tests/inheritance/reverse/filelevel/A.json
@@ -1,0 +1,3 @@
+{
+  "attrA": "valueFromA"
+}

--- a/tests/inheritance/reverse/filelevel/B.json
+++ b/tests/inheritance/reverse/filelevel/B.json
@@ -1,0 +1,4 @@
+{
+  "attrA": "valueFromB",
+  "attrB": "valueFromB"
+}

--- a/tests/inheritance/reverse/filelevel/C.json
+++ b/tests/inheritance/reverse/filelevel/C.json
@@ -1,0 +1,7 @@
+{
+  "$extends": ["D.json", "E.json"],
+  "$includes": ["B.json", "A.json"],
+  "attrA": "valueFromC",
+  "attrB": "valueFromC",
+  "attrC": "valueFromC"
+}

--- a/tests/inheritance/reverse/filelevel/D.json
+++ b/tests/inheritance/reverse/filelevel/D.json
@@ -1,0 +1,6 @@
+{
+  "attrA": "valueFromD",
+  "attrB": "valueFromD",
+  "attrC": "valueFromD",
+  "attrD": "valueFromD"
+}

--- a/tests/inheritance/reverse/filelevel/E.json
+++ b/tests/inheritance/reverse/filelevel/E.json
@@ -1,0 +1,7 @@
+{
+  "attrA": "valueFromE",
+  "attrB": "valueFromE",
+  "attrC": "valueFromE",
+  "attrD": "valueFromE",
+  "attrE": "valueFromE"
+}

--- a/tests/inheritance/reverse/filelevel/expected.json
+++ b/tests/inheritance/reverse/filelevel/expected.json
@@ -1,0 +1,7 @@
+{
+  "attrA": "valueFromA",
+  "attrB": "valueFromB",
+  "attrC": "valueFromC",
+  "attrD": "valueFromD",
+  "attrE": "valueFromE"
+}

--- a/tests/inheritance/reverse/filelevel/input.json
+++ b/tests/inheritance/reverse/filelevel/input.json
@@ -1,0 +1,3 @@
+{
+  "$extends": ["C.json"]
+}

--- a/tests/inheritance/reverse/filelevel/test.json
+++ b/tests/inheritance/reverse/filelevel/test.json
@@ -1,0 +1,3 @@
+{
+  "testType": "normal"
+}

--- a/tests/inheritance/reverse/nodelevel/A.json
+++ b/tests/inheritance/reverse/nodelevel/A.json
@@ -1,0 +1,3 @@
+{
+  "attrA": "valueFromA"
+}

--- a/tests/inheritance/reverse/nodelevel/B.json
+++ b/tests/inheritance/reverse/nodelevel/B.json
@@ -1,0 +1,4 @@
+{
+  "attrA": "valueFromB",
+  "attrB": "valueFromB"
+}

--- a/tests/inheritance/reverse/nodelevel/C.json
+++ b/tests/inheritance/reverse/nodelevel/C.json
@@ -1,0 +1,7 @@
+{
+  "$extends": ["D.json", "E.json"],
+  "$includes": ["B.json", "A.json"],
+  "attrA": "valueFromC",
+  "attrB": "valueFromC",
+  "attrC": "valueFromC"
+}

--- a/tests/inheritance/reverse/nodelevel/C.json
+++ b/tests/inheritance/reverse/nodelevel/C.json
@@ -1,7 +1,0 @@
-{
-  "$extends": ["D.json", "E.json"],
-  "$includes": ["B.json", "A.json"],
-  "attrA": "valueFromC",
-  "attrB": "valueFromC",
-  "attrC": "valueFromC"
-}

--- a/tests/inheritance/reverse/nodelevel/D.json
+++ b/tests/inheritance/reverse/nodelevel/D.json
@@ -1,0 +1,6 @@
+{
+  "attrA": "valueFromD",
+  "attrB": "valueFromD",
+  "attrC": "valueFromD",
+  "attrD": "valueFromD"
+}

--- a/tests/inheritance/reverse/nodelevel/E.json
+++ b/tests/inheritance/reverse/nodelevel/E.json
@@ -1,0 +1,7 @@
+{
+  "attrA": "valueFromE",
+  "attrB": "valueFromE",
+  "attrC": "valueFromE",
+  "attrD": "valueFromE",
+  "attrE": "valueFromE"
+}

--- a/tests/inheritance/reverse/nodelevel/expected.json
+++ b/tests/inheritance/reverse/nodelevel/expected.json
@@ -2,7 +2,7 @@
   "nodeLevelInheritance": {
     "attrA": "valueFromA",
     "attrB": "valueFromB",
-    "attrC": "valueFromC",
+    "attrC": "valueFromNode",
     "attrD": "valueFromD",
     "attrE": "valueFromE"
   }

--- a/tests/inheritance/reverse/nodelevel/expected.json
+++ b/tests/inheritance/reverse/nodelevel/expected.json
@@ -1,0 +1,9 @@
+{
+  "nodeLevelInheritance": {
+    "attrA": "valueFromA",
+    "attrB": "valueFromB",
+    "attrC": "valueFromC",
+    "attrD": "valueFromD",
+    "attrE": "valueFromE"
+  }
+}

--- a/tests/inheritance/reverse/nodelevel/input.json
+++ b/tests/inheritance/reverse/nodelevel/input.json
@@ -1,7 +1,15 @@
 {
   "nodeLevelInheritance": {
     "$extends": [
-      "C.json"
-    ]
+      "D.json",
+      "E.json"
+    ],
+    "$includes": [
+      "B.json",
+      "A.json"
+    ],
+    "attrA": "valueFromNode",
+    "attrB": "valueFromNode",
+    "attrC": "valueFromNode"
   }
 }

--- a/tests/inheritance/reverse/nodelevel/input.json
+++ b/tests/inheritance/reverse/nodelevel/input.json
@@ -1,0 +1,7 @@
+{
+  "nodeLevelInheritance": {
+    "$extends": [
+      "C.json"
+    ]
+  }
+}

--- a/tests/inheritance/reverse/nodelevel/test.json
+++ b/tests/inheritance/reverse/nodelevel/test.json
@@ -1,0 +1,3 @@
+{
+  "testType": "normal"
+}


### PR DESCRIPTION
Implement "reverse inheritance" feature.

When you design a data structure using JSON (or YAML), you often find that you want to define a template, where user custom files are inserted.


```json
{
  "company": "SPQR",
  "laptopSpec": {
    "cpu": "M1",
    "mem": "16GB",
    "storage": "512GB"
  },
  "userConfig" : {
    "userName": "eval:$(whoami)",
    "preferredShell": "zsh",
    "preferredWindowManager": "twm"
  }
}
```

Suppose that your users have their user preference files at `/userhome/.yourapp/config` as a JSON file.
You are thinking of overriding the elements under `userConfig` by the JSON config file.
But using the normal inheritance (`$extends`) here will not help.
Because the values you define in the base file as default values will override the user specific configuration.
Not the other way around.
What you can do here is "reverse inheritance" with the `$includes` keyword.

```json
{
  "company": "SPQR",
  "laptopSpec": {
    "cpu": "M1",
    "mem": "16GB",
    "storage": "512GB"
  },
  "userConfig" : {
    "$includes": [ "/userhome/.yourapp/config" ],
    "userName": "eval:$(whoami)",
    "preferredShell": "zsh",
    "preferredWindowManager": "twm"
  }
}
```
